### PR TITLE
adds alt_server_certs

### DIFF
--- a/chains_test.go
+++ b/chains_test.go
@@ -240,11 +240,13 @@ func Test_Assemble(t *testing.T) {
 		}))
 
 		identityCfg := Config{
-			Key:        "pem:" + keyPem,
-			Cert:       "pem:" + serverPem,
-			ServerCert: "pem:" + serverPem,
-			ServerKey:  "pem:" + keyPem,
-			CA:         "pem:" + caPem,
+			Key:  "pem:" + keyPem,
+			Cert: "pem:" + serverPem,
+			ServerPair: ServerPair{
+				ServerCert: "pem:" + serverPem,
+				ServerKey:  "pem:" + keyPem,
+			},
+			CA: "pem:" + caPem,
 		}
 
 		id, err := LoadIdentity(identityCfg)

--- a/chains_test.go
+++ b/chains_test.go
@@ -240,13 +240,11 @@ func Test_Assemble(t *testing.T) {
 		}))
 
 		identityCfg := Config{
-			Key:  "pem:" + keyPem,
-			Cert: "pem:" + serverPem,
-			ServerPair: ServerPair{
-				ServerCert: "pem:" + serverPem,
-				ServerKey:  "pem:" + keyPem,
-			},
-			CA: "pem:" + caPem,
+			Key:        "pem:" + keyPem,
+			Cert:       "pem:" + serverPem,
+			ServerCert: "pem:" + serverPem,
+			ServerKey:  "pem:" + keyPem,
+			CA:         "pem:" + caPem,
 		}
 
 		id, err := LoadIdentity(identityCfg)

--- a/config.go
+++ b/config.go
@@ -55,7 +55,8 @@ const (
 type Config struct {
 	Key            string       `json:"key" yaml:"key" mapstructure:"key"`
 	Cert           string       `json:"cert" yaml:"cert" mapstructure:"cert"`
-	ServerPair     `yaml:",inline"` //contains ServerCert & ServerKey, yaml requires `inline` JSON does not
+	ServerCert     string       `json:"server_cert,omitempty" yaml:"server_cert,omitempty" mapstructure:"server_cert,omitempty"`
+	ServerKey      string       `json:"server_key,omitempty" yaml:"server_key,omitempty" mapstructure:"server_key,omitempty"`
 	AltServerCerts []ServerPair `json:"alt_server_certs,omitempty" yaml:"alt_server_certs,omitempty" mapstructure:"alt_server_certs,omitempty"`
 	CA             string       `json:"ca,omitempty" yaml:"ca,omitempty" mapstructure:"ca"`
 }

--- a/identity.go
+++ b/identity.go
@@ -315,7 +315,32 @@ func LoadIdentity(cfg Config) (Identity, error) {
 				return nil, err
 			}
 
-			id.serverCert = ChainsToTlsCerts(chains, serverKey)
+			tlsCerts := ChainsToTlsCerts(chains, serverKey)
+			id.serverCert = append(id.serverCert, tlsCerts...)
+		}
+	}
+
+	// Alt Server Cert is optional
+	for _, altCert := range cfg.AltServerCerts {
+		if svrCert, err := loadCert(altCert.ServerCert); err != nil {
+			return id, err
+		} else {
+			serverKey := id.cert.PrivateKey
+			if altCert.ServerKey != "" {
+				serverKey, err = LoadKey(altCert.ServerKey)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			chains, err := AssembleServerChains(svrCert)
+
+			if err != nil {
+				return nil, err
+			}
+
+			tlsCerts := ChainsToTlsCerts(chains, serverKey)
+			id.serverCert = append(id.serverCert, tlsCerts...)
 		}
 	}
 

--- a/identity_test.go
+++ b/identity_test.go
@@ -170,12 +170,10 @@ func TestLoadIdentityWithAltServerCerts(t *testing.T) {
 	}
 
 	cfg := Config{
-		Key:  "pem:" + string(pem.EncodeToMemory(childKey1Pem)),
-		Cert: "pem:" + string(pem.EncodeToMemory(childCert1Pem)) + string(pem.EncodeToMemory(parentPem)),
-		ServerPair: ServerPair{
-			ServerKey:  "pem:" + string(pem.EncodeToMemory(childKey2Pem)),
-			ServerCert: "pem:" + string(pem.EncodeToMemory(childCert2Pem)) + string(pem.EncodeToMemory(parentPem)),
-		},
+		Key:        "pem:" + string(pem.EncodeToMemory(childKey1Pem)),
+		Cert:       "pem:" + string(pem.EncodeToMemory(childCert1Pem)) + string(pem.EncodeToMemory(parentPem)),
+		ServerKey:  "pem:" + string(pem.EncodeToMemory(childKey2Pem)),
+		ServerCert: "pem:" + string(pem.EncodeToMemory(childCert2Pem)) + string(pem.EncodeToMemory(parentPem)),
 		AltServerCerts: []ServerPair{
 			{
 				ServerKey:  "pem:" + string(pem.EncodeToMemory(childKey3Pem)),

--- a/identity_test.go
+++ b/identity_test.go
@@ -34,7 +34,6 @@ import (
 func mkCert(cn string, dns []string) (crypto.Signer, *x509.Certificate) {
 	key, _ := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
 
-
 	cert := &x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: cn,
@@ -115,6 +114,113 @@ func TestLoadIdentityWithPEMChain(t *testing.T) {
 	assert.NotNil(t, id.Cert().Leaf)
 	assert.Equal(t, id.Cert().Leaf.Subject.CommonName, "Test Child")
 	assert.Equal(t, key.Public(), id.Cert().Leaf.PublicKey)
+
+}
+
+func TestLoadIdentityWithAltServerCerts(t *testing.T) {
+	// setup
+	parentKey, parentCert := mkCert("Parent", []string{})
+	parentDer, _ := x509.CreateCertificate(rand.Reader, parentCert, parentCert, parentKey.Public(), parentKey)
+
+	childKey1, childCert1 := mkCert("Test Child 1", []string{"client1.netfoundry.io"})
+	childCert1Der, _ := x509.CreateCertificate(rand.Reader, childCert1, parentCert, childKey1.Public(), parentKey)
+
+	childKey2, childCert2 := mkCert("Test Child 2", []string{"client2.netfoundry.io"})
+	childCert2Der, _ := x509.CreateCertificate(rand.Reader, childCert2, parentCert, childKey2.Public(), parentKey)
+
+	childKey3, childCert3 := mkCert("Test Child 3", []string{"client3.netfoundry.io"})
+	childCert3Der, _ := x509.CreateCertificate(rand.Reader, childCert3, parentCert, childKey3.Public(), parentKey)
+
+	childKey1Der, _ := x509.MarshalECPrivateKey(childKey1.(*ecdsa.PrivateKey))
+	childKey1Pem := &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: childKey1Der,
+	}
+
+	childKey2Der, _ := x509.MarshalECPrivateKey(childKey2.(*ecdsa.PrivateKey))
+	childKey2Pem := &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: childKey2Der,
+	}
+
+	childKey3Der, _ := x509.MarshalECPrivateKey(childKey3.(*ecdsa.PrivateKey))
+	childKey3Pem := &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: childKey3Der,
+	}
+
+	parentPem := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: parentDer,
+	}
+
+	childCert1Pem := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: childCert1Der,
+	}
+
+	childCert2Pem := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: childCert2Der,
+	}
+
+	childCert3Pem := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: childCert3Der,
+	}
+
+	cfg := Config{
+		Key:  "pem:" + string(pem.EncodeToMemory(childKey1Pem)),
+		Cert: "pem:" + string(pem.EncodeToMemory(childCert1Pem)) + string(pem.EncodeToMemory(parentPem)),
+		ServerPair: ServerPair{
+			ServerKey:  "pem:" + string(pem.EncodeToMemory(childKey2Pem)),
+			ServerCert: "pem:" + string(pem.EncodeToMemory(childCert2Pem)) + string(pem.EncodeToMemory(parentPem)),
+		},
+		AltServerCerts: []ServerPair{
+			{
+				ServerKey:  "pem:" + string(pem.EncodeToMemory(childKey3Pem)),
+				ServerCert: "pem:" + string(pem.EncodeToMemory(childCert3Pem)) + string(pem.EncodeToMemory(parentPem)),
+			},
+		},
+	}
+
+	id, err := LoadIdentity(cfg)
+
+	t.Run("loads without error", func(t *testing.T) {
+		assert.NoError(t, err)
+	})
+
+	t.Run("has the correct client certificate", func(t *testing.T) {
+		assert.NotNil(t, id.Cert())
+		assert.Equal(t, 2, len(id.Cert().Certificate))
+		assert.NotNil(t, id.Cert().Leaf)
+		assert.Equal(t, "Test Child 1", id.Cert().Leaf.Subject.CommonName)
+		assert.Equal(t, childKey1.Public(), id.Cert().Leaf.PublicKey)
+	})
+
+	t.Run("has the correct server certificates", func(t *testing.T) {
+		serverTlsCerts := id.ServerCert()
+
+		certsToKeys := map[any]*ecdsa.PrivateKey{
+			childCert2.Subject.String(): childKey2.(*ecdsa.PrivateKey),
+			childCert3.Subject.String(): childKey3.(*ecdsa.PrivateKey),
+		}
+
+		foundServerCerts := map[string]bool{
+			childCert2.Subject.String(): false,
+			childCert3.Subject.String(): false,
+		}
+
+		for _, cert := range serverTlsCerts {
+			if certsToKeys[cert.Leaf.Subject.String()].Equal(cert.PrivateKey) {
+				foundServerCerts[cert.Leaf.Subject.String()] = true
+			}
+		}
+
+		for subject, found := range foundServerCerts {
+			assert.True(t, found, "certificate %s was not found in the TLS config", subject)
+		}
+	})
 
 }
 

--- a/token.go
+++ b/token.go
@@ -52,17 +52,19 @@ func NewIdentity(id Identity) *TokenId {
 
 func (i *TokenId) ShallowCloneWithNewToken(token string) *TokenId {
 	return &TokenId{
-		Identity:    i.Identity,
-		Token: token,
+		Identity: i.Identity,
+		Token:    token,
 	}
 }
 
 func LoadServerIdentity(clientCertPath, serverCertPath, keyPath, caCertPath string) (*TokenId, error) {
 	idCfg := Config{
-		Key:        keyPath,
-		Cert:       clientCertPath,
-		ServerCert: serverCertPath,
-		CA:         caCertPath,
+		Key:  keyPath,
+		Cert: clientCertPath,
+		ServerPair: ServerPair{
+			ServerCert: serverCertPath,
+		},
+		CA: caCertPath,
 	}
 
 	if id, err := LoadIdentity(idCfg); err != nil {

--- a/token.go
+++ b/token.go
@@ -59,12 +59,10 @@ func (i *TokenId) ShallowCloneWithNewToken(token string) *TokenId {
 
 func LoadServerIdentity(clientCertPath, serverCertPath, keyPath, caCertPath string) (*TokenId, error) {
 	idCfg := Config{
-		Key:  keyPath,
-		Cert: clientCertPath,
-		ServerPair: ServerPair{
-			ServerCert: serverCertPath,
-		},
-		CA: caCertPath,
+		Key:        keyPath,
+		Cert:       clientCertPath,
+		ServerCert: serverCertPath,
+		CA:         caCertPath,
 	}
 
 	if id, err := LoadIdentity(idCfg); err != nil {


### PR DESCRIPTION
alt_server_certs are used to build the tls.Config for listeners. This
alternate array of cert chain/keys allows externaly generated server
certificates to be used without worrying about higher level (ziti)
components overwritting them during enrollment extension.
alt_server_certs is specifically added to support Lets Encrypt
scenarios for routers.