### PR TITLE
allow to disable pkcs11 driver at build time

### DIFF
--- a/certtools/engines.go
+++ b/certtools/engines.go
@@ -32,7 +32,11 @@ type Engine interface {
 var engines = map[string]Engine{}
 
 func init() {
-	engines[pkcs11.EngineId] = pkcs11.Engine
+
+	if p11Engine, ok := pkcs11.GetEngine().(Engine); ok {
+		engines[p11Engine.Id()] = p11Engine
+	}
+
 	engines[parsec.EngineId] = parsec.Engine
 }
 

--- a/engines/pkcs11/disable_pkcs11.go
+++ b/engines/pkcs11/disable_pkcs11.go
@@ -1,0 +1,23 @@
+//go:build no_pkcs11
+
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package pkcs11
+
+func GetEngine() interface{} {
+	return nil
+}

--- a/engines/pkcs11/engine_test.go
+++ b/engines/pkcs11/engine_test.go
@@ -52,6 +52,7 @@ type ecdsaSig struct {
 
 func Test_softhsm2_keys(t *testing.T) {
 	pkcs11Lib := getPkcs11Lib()
+	eng := GetEngine().(*engine)
 
 	if _, err := os.Stat(pkcs11Lib); err != nil {
 		t.Logf("skipping %s: driver not found", t.Name())
@@ -73,7 +74,7 @@ func Test_softhsm2_keys(t *testing.T) {
 			t.Error(err)
 		}
 
-		key, err := Engine.LoadKey(k)
+		key, err := eng.LoadKey(k)
 		if err != nil {
 			t.Error(err)
 		} else {

--- a/engines/pkcs11/id.go
+++ b/engines/pkcs11/id.go
@@ -1,0 +1,25 @@
+/*
+	Copyright NetFoundry Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package pkcs11
+
+const EngineId = "pkcs11"
+
+type engine struct {
+}
+
+func (*engine) Id() string {
+	return EngineId
+}


### PR DESCRIPTION
allow building applications without PKCS11 support (requested in openziti/sdk-golang#298)

`no_pkcs11` tag controls exclusion of pkcs11 support:

```
$ go build -tags no_pkcs11 ./...
```