### PR TITLE
tracks intermediate vs root CAs to allow for different chain needs

### DIFF
--- a/ca_pool.go
+++ b/ca_pool.go
@@ -17,27 +17,115 @@
 package identity
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
+	"github.com/pkg/errors"
 )
 
 type CaPool struct {
-	certs []*x509.Certificate
+	roots         map[string]*x509.Certificate
+	intermediates map[string]*x509.Certificate
 }
 
 func NewCaPool(certs []*x509.Certificate) *CaPool {
 	result := &CaPool{
-		certs: certs,
+		roots:         make(map[string]*x509.Certificate),
+		intermediates: make(map[string]*x509.Certificate),
+	}
+
+	for _, cert := range certs {
+		_ = result.AddCa(cert)
 	}
 	return result
 }
 
-func (self *CaPool) isSelfSignedCA(cert *x509.Certificate) bool {
-	return cert.IsCA && cert.CheckSignatureFrom(cert) == nil
+// AddCa adds a CA (root or intermediate) certificate to the current pool. It returns an error if the
+// certificate is not CA.
+func (self *CaPool) AddCa(cert *x509.Certificate) error {
+	if !cert.IsCA {
+		return errors.New("x509 certificates does not have the CA flag set to true")
+	}
+
+	hash := hashCertSha256(cert)
+
+	if IsRootCa(cert) {
+		self.roots[hash] = cert
+	} else {
+		self.intermediates[hash] = cert
+	}
+
+	return nil
+}
+
+// Roots returns a copy of the slice of currently added roots
+func (self *CaPool) Roots() []*x509.Certificate {
+	rootsCopy := make([]*x509.Certificate, len(self.roots))
+
+	for _, cert := range self.roots {
+		rootsCopy = append(rootsCopy, cert)
+	}
+
+	return rootsCopy
+}
+
+// NumCerts returns the number of certificates under management in this pool. Useful
+// for checking of the pools has been altered as certificate removal from the pool
+// is not supported.
+func (self *CaPool) NumCerts() int {
+	return len(self.intermediates) + len(self.roots)
+}
+
+// Intermediates returns a copy of the slice of currently added intermediates
+func (self *CaPool) Intermediates() []*x509.Certificate {
+	intermediatesCopy := make([]*x509.Certificate, len(self.intermediates))
+
+	for _, cert := range self.roots {
+		intermediatesCopy = append(intermediatesCopy, cert)
+	}
+
+	return intermediatesCopy
+}
+
+// hashCertSha256 returns the sha256 fingerprint of a certificate
+func hashCertSha256(cert *x509.Certificate) string {
+	hash := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(hash[:])
+}
+
+// rootsAsMap returns the root CAs in a new map
+func (self *CaPool) rootsAsMap() map[string]*x509.Certificate {
+	rootsCopy := make(map[string]*x509.Certificate, len(self.roots))
+	for k, v := range self.roots {
+
+		rootsCopy[k] = v
+	}
+	return rootsCopy
+}
+
+// intermediatesAsMap returns the intermediate CAs in a new map
+func (self *CaPool) intermediatesAsMap() map[string]*x509.Certificate {
+	intermediatesCopy := make(map[string]*x509.Certificate, len(self.intermediates))
+	for k, v := range self.intermediates {
+		intermediatesCopy[k] = v
+	}
+	return intermediatesCopy
+}
+
+// allCasAsMap returns all root and intermediate CAs in a new map
+func (self *CaPool) allCasAsMap() map[string]*x509.Certificate {
+	allCasMap := self.intermediatesAsMap()
+	roots := self.rootsAsMap()
+	for k, v := range roots {
+		allCasMap[k] = v
+	}
+
+	return allCasMap
 }
 
 // GetChainMinusRoot returns a chain from `cert` up to, but not including, the root CA if possible. If no cert is
 // provided, nil is returned, if no chains is assembled the resulting chain will be the target cert only.
-func (self *CaPool) GetChainMinusRoot(cert *x509.Certificate, extraCerts ...*x509.Certificate) []*x509.Certificate {
+func (self *CaPool) GetChainMinusRoot(cert *x509.Certificate, additionalCerts ...*x509.Certificate) []*x509.Certificate {
 	if cert == nil {
 		return nil
 	}
@@ -45,23 +133,19 @@ func (self *CaPool) GetChainMinusRoot(cert *x509.Certificate, extraCerts ...*x50
 	var result []*x509.Certificate
 	result = append(result, cert)
 
-	certs := map[*x509.Certificate]struct{}{}
-	self.addNonSelfSignedCasToCertsMap(certs, self.certs)
-	self.addNonSelfSignedCasToCertsMap(certs, extraCerts)
+	chainCandidates := self.intermediatesAsMap()
 
-	for {
-		if parent := self.getParent(cert, certs); parent != nil {
-			result = append(result, parent)
-			cert = parent
-		} else {
-			return result
-		}
+	for _, curCert := range additionalCerts {
+		hash := hashCertSha256(curCert)
+		chainCandidates[hash] = curCert
 	}
+
+	return assembleChain(cert, chainCandidates)
 }
 
 // GetChain returns a chain from `cert` up and including the root CA if possible. If no cert is provided, nil is
 // returned. If no chains is assembled the resulting chain will be the target cert only.
-func (self *CaPool) GetChain(cert *x509.Certificate, extraCerts ...*x509.Certificate) []*x509.Certificate {
+func (self *CaPool) GetChain(cert *x509.Certificate, additionalCerts ...*x509.Certificate) []*x509.Certificate {
 	if cert == nil {
 		return nil
 	}
@@ -69,39 +153,54 @@ func (self *CaPool) GetChain(cert *x509.Certificate, extraCerts ...*x509.Certifi
 	var result []*x509.Certificate
 	result = append(result, cert)
 
-	certs := map[*x509.Certificate]struct{}{}
+	chainCandidates := self.allCasAsMap()
 
-	for _, curCert := range self.certs {
-		certs[curCert] = struct{}{}
+	for _, curCert := range additionalCerts {
+		hash := hashCertSha256(curCert)
+		chainCandidates[hash] = curCert
 	}
-	for _, curCert := range extraCerts {
-		certs[curCert] = struct{}{}
+
+	return assembleChain(cert, chainCandidates)
+}
+
+// assembleChain starts at `startCert` and build the longest chain up through ancestor signing certs as it can from `chainCandidates`.
+func assembleChain(startCert *x509.Certificate, chainCandidates map[string]*x509.Certificate) []*x509.Certificate {
+	if startCert == nil {
+		return nil
 	}
+
+	var result []*x509.Certificate
+	result = append(result, startCert)
+
+	curCert := startCert
 
 	for {
-		if parent := self.getParent(cert, certs); parent != nil {
+		if parent := getParent(curCert, chainCandidates); parent != nil {
 			result = append(result, parent)
-			cert = parent
+			curCert = parent
 		} else {
 			return result
 		}
 	}
 }
 
-func (self *CaPool) addNonSelfSignedCasToCertsMap(certMap map[*x509.Certificate]struct{}, certs []*x509.Certificate) {
-	for _, cert := range certs {
-		if cert.IsCA && !self.isSelfSignedCA(cert) {
-			certMap[cert] = struct{}{}
-		}
-	}
-}
-
-func (self *CaPool) getParent(cert *x509.Certificate, certs map[*x509.Certificate]struct{}) *x509.Certificate {
-	for candidate := range certs {
-		if err := cert.CheckSignatureFrom(candidate); err == nil {
-			delete(certs, candidate)
-			return candidate
+// getParent returns the direct signing parent of a certificate found in a supplied map of certs. The supplied map
+// is altered to remove the signing parent if found.
+func getParent(cert *x509.Certificate, candidates map[string]*x509.Certificate) *x509.Certificate {
+	for hash, candidate := range candidates {
+		//cheaply check distinguishing names, verify with signature checking similar to OpenSSL
+		if cert.Issuer.String() == candidate.Subject.String() {
+			if err := cert.CheckSignatureFrom(candidate); err == nil {
+				delete(candidates, hash)
+				return candidate
+			}
 		}
 	}
 	return nil
+}
+
+// IsRootCa returns true if a certificate is a root certificate (is a ca, distinguishing name match on subject/issuer, and is self-signed)
+func IsRootCa(cert *x509.Certificate) bool {
+	//checking done in highest to lowest cost: CA flag, distinguishing name matching, signature check
+	return cert.IsCA && cert.Issuer.String() == cert.Subject.String() && cert.CheckSignatureFrom(cert) == nil
 }


### PR DESCRIPTION
- switches to using hashes to de-dupe certs instead of pointers
- use subject string checking to preface signature checking
- expose IsRootCa as a helper function
- adds doc to functions/methods