### PR TITLE
Fix golangci-lint CI for go 1.25 modules

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
 
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+version: "2"
+linters:
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST1000" # Incorrect or missing package comment
+        - "-ST1003" # Poorly chosen identifier
+        - "-ST1006" # Poorly chosen receiver name (self/this is an openziti convention)
+        - "-ST1016" # Methods on the same type should have the same receiver name
+        - "-ST1020" # The documentation of an exported function should start with the function's name
+        - "-ST1021" # The documentation of an exported type should start with type's name
+        - "-QF1008" # Could remove embedded field from selector

--- a/certtools/keys.go
+++ b/certtools/keys.go
@@ -157,7 +157,7 @@ func SavePrivateKey(key crypto.PrivateKey, file string) error {
 		t = "EC PRIVATE KEY"
 		der, _ = x509.MarshalECPrivateKey(ecK)
 	} else {
-		return fmt.Errorf("Unsupported key type")
+		return fmt.Errorf("unsupported key type")
 	}
 
 	keyPem := &pem.Block{Type: t, Bytes: der}


### PR DESCRIPTION
The `lint` job fails at startup on every PR: `golangci/golangci-lint-action@v6` installs golangci-lint v1.64.8 (built with go1.24), which refuses to run against this `go 1.25.0` module. golangci-lint never lints anything; the job just errors.

This brings identity in line with the other openziti repos (ziti, foundation, channel, transport, sdk-golang), which all use `golangci-lint-action@v9` with a `version: "2"` `.golangci.yml`:

- bumps the action `@v6` -> `@v9` (installs golangci-lint 2.x)
- adds a `.golangci.yml` with the ecosystem-standard staticcheck exclude list, so the style/quickfix checks v2 folded into `staticcheck` (and that the repo never opted into, like the `self`/`this` receiver convention) stay off
- lowercases a capitalized error string in `certtools/keys.go`, the single issue the exclude list does not cover

Validated locally: `golangci-lint run ./...` reports 0 issues; build stays green. Pre-existing/repo-wide CI fix, independent of any feature work.

Fixes #74